### PR TITLE
Fix error in TravisCI's node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ language: node_js
 node_js:
 - 6.10
 - 8.11
-- 10.6
+- 10.4
+# mock-fsが node v10.5以上で、fs.promiseのcallbackが動作しないため、暫定として10.4を指定

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "package.json"
   ],
   "devDependencies": {
-    "@types/node": "10.12.0",
+    "@types/node": "10.12.2",
     "@types/jasmine": "~2.8.2",
     "@types/mock-fs": "~3.6.30",
     "shx": "~0.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "package.json"
   ],
   "devDependencies": {
-    "@types/node": "10.12.2",
+    "@types/node": "6.0.46",
     "@types/jasmine": "~2.8.2",
     "@types/mock-fs": "~3.6.30",
     "shx": "~0.2.2",
@@ -35,7 +35,7 @@
     "istanbul": "^0.3.2",
     "remark-cli": "~2.0.0",
     "remark-lint": "~5.0.1",
-    "mock-fs": "~4.7.0",
+    "mock-fs": "~4.5.0",
     "tslint": "~5.4.3",
     "typescript": "~2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "package.json"
   ],
   "devDependencies": {
-    "@types/node": "6.0.46",
+    "@types/node": "10.12.0",
     "@types/jasmine": "~2.8.2",
     "@types/mock-fs": "~3.6.30",
     "shx": "~0.2.2",
@@ -35,7 +35,7 @@
     "istanbul": "^0.3.2",
     "remark-cli": "~2.0.0",
     "remark-lint": "~5.0.1",
-    "mock-fs": "~4.5.0",
+    "mock-fs": "~4.7.0",
     "tslint": "~5.4.3",
     "typescript": "~2.6.1"
   },


### PR DESCRIPTION
## このpull requestが解決する内容

TravisCIのnode v10でエラーとなる問題の修正
 - 必要なモジュールを最新verへ修正
 - .travis.yml のnodeのv10系の指定を10.4へ修正
     - mock-fsにてnode v10.5以上の場合、fs.Promiseのcallbackが動作しない問題があるため

ロジック自体には影響がないため、セルフマージとする。